### PR TITLE
Added unit test for issue #5 with paranamer using PropertyNamingStrategy

### DIFF
--- a/src/test/java/com/fasterxml/jackson/module/paranamer/TestCreatorWithNamingStrategy.java
+++ b/src/test/java/com/fasterxml/jackson/module/paranamer/TestCreatorWithNamingStrategy.java
@@ -1,0 +1,35 @@
+package com.fasterxml.jackson.module.paranamer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+
+
+public class TestCreatorWithNamingStrategy
+		extends ParanamerTestBase {
+
+	static class CreatorBean
+	{
+		protected String myName;
+		protected int myAge;
+
+		@JsonCreator
+		public CreatorBean(int myAge, String myName)
+		{
+			this.myName = myName;
+			this.myAge = myAge;
+		}
+	}
+
+	private final ObjectMapper MAPPER = new ObjectMapper()
+			.registerModule(new ParanamerModule())
+			.setPropertyNamingStrategy(PropertyNamingStrategy.PASCAL_CASE_TO_CAMEL_CASE);
+
+	public void testSimpleConstructor() throws Exception
+	{
+		CreatorBean bean = MAPPER.readValue("{ \"MyAge\" : 42,  \"myName\" : \"NotMyRealName\" }", CreatorBean.class);
+		assertEquals(42, bean.myAge);
+		assertEquals("NotMyRealName", bean.myName);
+	}
+
+}


### PR DESCRIPTION
Unit test for issue #5 that asserts paranamer working with the Pascal naming strategy.  The issue was fixed in jackson-databind in https://github.com/FasterXML/jackson-databind/pull/379
